### PR TITLE
Fixed serializer attribute and viewset clean-up

### DIFF
--- a/pizzaapi/serializers/lineitem_serializer.py
+++ b/pizzaapi/serializers/lineitem_serializer.py
@@ -6,9 +6,7 @@ from .product_serializer import PizzaToppingSerializer
 class LineItemSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(source="product.id", read_only=True)
     name = serializers.CharField(source="product.name", read_only=True)
-    price = serializers.DecimalField(
-        source="product.price", max_digits=10, decimal_places=2, read_only=True
-    )
+    price = serializers.FloatField(source="product.price", read_only=True)
     toppings = PizzaToppingSerializer(
         source="pizza_toppings", many=True, read_only=True
     )

--- a/pizzaapi/views/order_viewset.py
+++ b/pizzaapi/views/order_viewset.py
@@ -2,14 +2,12 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from ..models.order import Order
-# from ..permissions.order_permissions import OrderPermission
 from ..serializers.order_serializer import OrderSerializer
 
 
 class OrderViewSet(viewsets.ModelViewSet):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
-    # permission_classes = [OrderPermission]
 
     # Override get_queryset to filter by cart or orders
     def get_queryset(self):
@@ -20,14 +18,6 @@ class OrderViewSet(viewsets.ModelViewSet):
         # Regular users only see their orders
         return Order.objects.filter(customer__user=user)
 
-    # Action to fetch cart items only (PENDING orders with no payment)
-    @action(detail=False, methods=["get"], url_path="cart")
-    def get_cart(self, request):
-        user = request.user
-        cart = Order.objects.filter(customer__user=user, payment=None, status="PENDING")
-        serializer = self.get_serializer(cart, many=True)
-        return Response(serializer.data)
-
     # Action to fetch completed orders (those with payments and a status)
     @action(detail=False, methods=["get"], url_path="completed")
     def get_completed_orders(self, request):
@@ -35,7 +25,7 @@ class OrderViewSet(viewsets.ModelViewSet):
         completed_orders = Order.objects.filter(
             customer__user=user,
             payment__isnull=False,
-            status__in=["IN_PROCESS", "COMPLETED"],
+            status__in=["IN_PROCESS", "In Process", "COMPLETED", "Completed"],
         )
         serializer = self.get_serializer(completed_orders, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
- Changed the serializer attribute of `price` in `LineItemSerializer` from `DecimalField` to `FloatField` so product price would return as a number and not a string. 
- Removed unused `OrderPermission` and `get_cart` method from `OrderViewSet`