### PR TITLE
Add Profile Update Functionality

### DIFF
--- a/pizzaapi/views/user_viewset.py
+++ b/pizzaapi/views/user_viewset.py
@@ -58,3 +58,39 @@ class UserViewSet(viewsets.ModelViewSet):
                 "orders": orders_serializer.data,
             }
         )
+
+    @action(detail=False, methods=["patch"], url_path="profile")
+    def update_profile(self, request):
+        user = request.user
+        profile = Profile.objects.get(user=user)
+
+        # Separate user and profile fields
+        user_fields = ["username", "first_name", "last_name", "email"]
+        profile_fields = ["phone_number", "address"]
+
+        # Update User model fields
+        user_data = {
+            key: request.data[key] for key in user_fields if key in request.data
+        }
+        if user_data:
+            user_serializer = UserSerializer(user, data=user_data, partial=True)
+            if user_serializer.is_valid():
+                user_serializer.save()
+            else:
+                return Response(user_serializer.errors, status=400)
+
+        # Update Profile model fields
+        profile_data = {
+            key: request.data[key] for key in profile_fields if key in request.data
+        }
+        if profile_data:
+            profile_serializer = ProfileSerializer(
+                profile, data=profile_data, partial=True
+            )
+            if profile_serializer.is_valid():
+                profile_serializer.save()
+            else:
+                return Response(profile_serializer.errors, status=400)
+
+        # Return updated profile data
+        return self.profile(request)

--- a/pizzaproject/urls.py
+++ b/pizzaproject/urls.py
@@ -16,5 +16,9 @@ urlpatterns = [
     path("", include(router.urls)),
     path("login", LoginViewSet.as_view(), name="login"),
     path("register", RegisterViewSet.as_view(), name="register"),
-    path("profile/", UserViewSet.as_view({"get": "profile"}), name="profile"),
+    path(
+        "profile/",
+        UserViewSet.as_view({"get": "profile", "patch": "update_profile"}),
+        name="profile",
+    ),
 ]


### PR DESCRIPTION
# Add Profile Update Functionality

## Changes Made
- Added PATCH endpoint to `/profile/` route to handle user profile updates
- Enhanced UserViewSet to manage updates for both User and Profile models
- Implemented field-specific updates for User fields (username, first_name, last_name, email) and Profile fields (phone_number, address)
- Ensured proper data validation and error handling for profile updates

## Technical Details
- Modified UserViewSet to include update_profile method with PATCH support
- Implemented separate handling for User model fields vs Profile model fields
- Returns complete user data response including profile, payments, and orders
- Maintains existing authentication and permission requirements

## Testing
- Verified PATCH requests successfully update individual fields
- Confirmed data persistence in both User and Profile models
- Validated proper error handling for invalid data
- Tested token authentication requirements